### PR TITLE
Print message instead of "Unexpected exception"

### DIFF
--- a/lib/dot_reporter.dart
+++ b/lib/dot_reporter.dart
@@ -140,8 +140,13 @@ class DotReporter {
         break;
     }
 
-    if (model.message != null && showMessage) {
-      base += '\n' + model.message;
+    if (model.state == State.Failure && showMessage) {
+      if (model.error != null) {
+        base += '\n' + model.error;
+      }
+      if (model.message != null) {
+        base += '\n' + model.message;
+      }
     }
     if (showId) {
       return '${model.id} $base';

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -7,6 +7,7 @@ enum State {
 class TestModel {
   int id;
   String name;
+  String error;
   String message;
   State state;
 
@@ -15,6 +16,7 @@ class TestModel {
     if (other is TestModel) {
       return id == other.id &&
           name == other.name &&
+          error == other.error &&
           message == other.message &&
           state == other.state;
     }
@@ -23,6 +25,6 @@ class TestModel {
 
   @override
   String toString() {
-    return 'TestModel { $id $state $name $message }';
+    return 'TestModel { $id $state $name $error $message }';
   }
 }

--- a/lib/parser.dart
+++ b/lib/parser.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
 
 import 'model.dart';
 
@@ -26,6 +26,7 @@ class Parser {
     if (line.containsKey('type')) {
       _parseTestStart(line);
       _parseTestError(line);
+      _parseTestMessage(line);
       _parseTestDone(line);
     }
   }
@@ -55,11 +56,21 @@ class Parser {
 
       final model = tests[id];
       if (model != null) {
-        if (error.startsWith('Test failed. See exception logs above.')) {
-          model.message = '\tUnexpected exception.\n';
-        } else {
-          model.message = error.endsWith('\n') ? '\t$error' : '\t$error\n';
+        if (!error.startsWith('Test failed. See exception logs above.')) {
+          model.error = error.endsWith('\n') ? '\t$error' : '\t$error\n';
         }
+      }
+    }
+  }
+
+  void _parseTestMessage(Map<String, dynamic> line) {
+    if (line['type'] == 'print') {
+      int id = line['testID'];
+      String message = line['message'];
+
+      final model = tests[id];
+      if (model != null && message != null) {
+        model.message = '\t$message\n';
       }
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,363 +7,384 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "14.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.2+1"
+    version: "0.41.2"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.1.0"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.0"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.7.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+3"
+    version: "0.15.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
-  csslib:
+    version: "3.0.0"
+  dart_style:
     dependency: transitive
     description:
-      name: csslib
+      name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "1.3.12"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.0+2"
+    version: "2.0.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+2"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
+    version: "1.0.0"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1+2"
+    version: "4.1.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.8"
+    version: "1.4.13"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
-  package_resolver:
-    dependency: transitive
-    description:
-      name: package_resolver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.10"
+    version: "1.9.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "2.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.1.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.10+3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.8"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.4"
+    version: "1.16.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.19"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.3.15"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "6.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+13"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.5.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/test/dart_dot_reporter_test.dart
+++ b/test/dart_dot_reporter_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:dart_dot_reporter/dot_reporter.dart';
-import 'package:dart_dot_reporter/parser.dart';
 import 'package:dart_dot_reporter/model.dart';
+import 'package:dart_dot_reporter/parser.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -11,7 +11,7 @@ void main() {
     final model = TestModel();
     expect(model.id, null);
     expect(model.name, null);
-    expect(model.message, null);
+    expect(model.error, null);
     expect(model.state, null);
   });
 
@@ -39,7 +39,7 @@ void main() {
           TestModel()
             ..id = 29
             ..state = State.Failure
-            ..message =
+            ..error =
                 "\tExpected: {\n            'id': 103\n          }\n  Actual: {\n            'ids': 102,\n          }\n   Which: is missing map key 'id'\n"
             ..name = 'API update');
       expect(
@@ -52,6 +52,9 @@ void main() {
           TestModel()
             ..id = 31
             ..state = State.Failure
+            ..error = null
+            ..message =
+                '''\t══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════\nThe following NoSuchMethodError was thrown building Button(dirty, dependencies:\n[Theme]):\nThe getter 'theme' was called on null.\nReceiver: null\nTried calling: theme\n\nWidget creation tracking is currently disabled. Enabling it enables improved error messages. It can\nbe enabled by passing `--track-widget-creation` to `flutter run` or `flutter test`.\n\nWhen the exception was thrown, this was the stack:\n#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)\n#1      Theme.of (package:app/theme/theme.dart:59:10)\n#2      Button.build (package:app/widget/button.dart:32:28)\n#3      StatelessElement.build (package:flutter/src/widgets/framework.dart:4009:28)\n#4      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3941:15)\n#5      Element.rebuild (package:flutter/src/widgets/framework.dart:3738:5)\n#6      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:3924:5)\n#7      ComponentElement.mount (package:flutter/src/widgets/framework.dart:3919:5)\n#8      Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#9      Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#10     SingleChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5127:14)\n#11     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#12     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#13     SingleChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5127:14)\n#14     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#15     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#16     ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3961:16)\n#17     Element.rebuild (package:flutter/src/widgets/framework.dart:3738:5)\n#18     ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:3924:5)\n#19     ComponentElement.mount (package:flutter/src/widgets/framework.dart:3919:5)\n#20     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#21     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#22     SingleChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5127:14)\n#23     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#24     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#25     SingleChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5127:14)\n#26     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#27     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#28     SingleChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5127:14)\n#29     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#30     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#31     SingleChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5127:14)\n#32     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#33     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#34     ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3961:16)\n#35     Element.rebuild (package:flutter/src/widgets/framework.dart:3738:5)\n#36     ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:3924:5)\n#37     StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4088:11)\n#38     ComponentElement.mount (package:flutter/src/widgets/framework.dart:3919:5)\n#39     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3101:14)\n#40     Element.updateChild (package:flutter/src/widgets/framework.dart:2904:12)\n#41     ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3961:16)\n#42     Element.rebuild (package:flutter/src/widgets/framework.dart:3738:5)\n#43     ComponentElement._firstBuild (package:flutter/src/widgets\n(elided 36 frames from class _FakeAsync, package dart:async, package dart:async-patch, and package stack_trace)\n\n════════════════════════════════════════════════════════════════════════════════════════════════════\n'''
             ..name = 'API too big print text');
     });
   });
@@ -69,8 +72,15 @@ void main() {
       ..id = 2
       ..name = 'error name'
       ..state = State.Failure
-      ..message =
+      ..error =
           "Expected: {\n            'id': 103\n          }\n  Actual: {\n            'ids': 102,\n          }\n   Which: is missing map key 'id'\n";
+
+    final messageTest = TestModel()
+      ..id = 31
+      ..state = State.Failure
+      ..error = null
+      ..message = 'A very long message'
+      ..name = 'message name';
 
     final successTest = TestModel()
       ..id = 1
@@ -166,6 +176,30 @@ void main() {
       verify(out.write(
               "X error name\nExpected: {\n            'id': 103\n          }\n  Actual: {\n            'ids': 102,\n          }\n   Which: is missing map key 'id'\n"))
           .called(1);
+      verify(out.writeAll(
+        [
+          'Total: 1',
+          'Success: 0',
+          'Skipped: 0',
+          'Failure: 1',
+        ],
+        '\n',
+      )).called(1);
+    });
+
+    test('Complex error with message test passed', () {
+      parser.tests[messageTest.id] = messageTest;
+      reporter = DotReporter(
+        noColor: true,
+        showMessage: true,
+        out: out,
+        parser: parser,
+      );
+      reporter.printReport();
+      expect(exitCode, 2);
+      verify(out.write('X')).called(1);
+      verify(out.writeln()).called(5);
+      verify(out.write('X message name\nA very long message')).called(1);
       verify(out.writeAll(
         [
           'Total: 1',


### PR DESCRIPTION
When a test failed, print the entire message instead of "Unexpected exception" in order to understand the fail.

Sample output:

```
......................................X...........................................................................................................................................................................................................................................................................................................................................................................................

X Test: Test Name
        ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure object was thrown running a test:
  Expected: one widget whose rasterized image matches golden image
"goldens/____.png"
  Actual: _KeyFinder:<exactly one widget with key [<'key'>] (ignoring offstage
widgets): MaterialGolden-[<'key'>]>
   Which: Could not be compared against non-existent file: "path/golden.phone.png"

When the exception was thrown, this was the stack:
#0      fail (package:test_api/src/frontend/expect.dart:155:31)
#1      _expect.<anonymous closure> (package:test_api/src/frontend/expect.dart:130:9)
#12     AutomatedTestWidgetsFlutterBinding.runAsync.<anonymous closure> (package:flutter_test/src/binding.dart)
<asynchronous suspension>
(elided 10 frames from dart:async, dart:async-patch, and package:stack_trace)

The test description was:
  Golden
════════════════════════════════════════════════════════════════════════════════════════════════════


Total: 418
Success: 417
Skipped: 0
Failure: 1
```